### PR TITLE
Retain /bin and .profile.d

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -8,14 +8,18 @@ CACHE_DIR="$2"
 ENV_DIR="$3"
 STAGE="$(mktemp -d)"
 
-if [ ! -f "${ENV_DIR}/APP_BASE" ]; then
-    echo "APP_BASE was not set. Aborting" | indent
-    exit 1
+if [[ -z "${APP_BASE}" ]]; then
+	if [ ! -f "${ENV_DIR}/APP_BASE" ]; then
+	    echo "APP_BASE was not set. Aborting" | indent
+	    exit 1
+	fi
+	APP_BASE="$(cat "${ENV_DIR}/APP_BASE")"
 fi
-APP_BASE="$(cat "${ENV_DIR}/APP_BASE")"
 
 (
     mv "${BUILD_DIR}/${APP_BASE}" "${STAGE}" &&
+    mv "${BUILD_DIR}/bin" "${STAGE}/${APP_BASE}" &&
+    mv "${BUILD_DIR}/.profile.d" "${STAGE}/${APP_BASE}" &&
     rm -rf "${BUILD_DIR}" &&
     mv "${STAGE}/$(basename "$APP_BASE")" "${BUILD_DIR}"
 )


### PR DESCRIPTION
As both `/bin` and `.profile.d` may contain useful elements that should not be overwritten (as is the case for outputs from `envkey-heroku-buildpack`), these are retained when the `APP_BASE` folder is copied to the root directory.