### PR TITLE
Only mv /bin & .profile.d if they exist

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -18,8 +18,8 @@ fi
 
 (
     mv "${BUILD_DIR}/${APP_BASE}" "${STAGE}" &&
-    mv "${BUILD_DIR}/bin" "${STAGE}/${APP_BASE}" &&
-    mv "${BUILD_DIR}/.profile.d" "${STAGE}/${APP_BASE}" &&
+    ([ ! -f "${BUILD_DIR}/bin" ] || mv "${BUILD_DIR}/bin" "${STAGE}/${APP_BASE}") &&
+    ([ ! -f "${BUILD_DIR}/.profile.d" ] || mv "${BUILD_DIR}/.profile.d" "${STAGE}/${APP_BASE}") &&
     rm -rf "${BUILD_DIR}" &&
     mv "${STAGE}/$(basename "$APP_BASE")" "${BUILD_DIR}"
 )


### PR DESCRIPTION
While working with the monorepo deployment buildpack I noticed that the `mv` commands introduced in #1 fail for non-envkey environments when `.profile.d` doesn't exist. This PR adds one liner checks for the `/bin` and `.profile.d` files to only move them if necessary.